### PR TITLE
.md 側の DirectLink が適切に HTML に変換されるようにした

### DIFF
--- a/HtmlGen.fsi
+++ b/HtmlGen.fsi
@@ -1,0 +1,6 @@
+module HtmlGen
+
+open Giraffe.ViewEngine
+open FSharp.Formatting.Markdown
+
+val mdDocToHtml : MarkdownDocument -> XmlNode list

--- a/Program.fs
+++ b/Program.fs
@@ -82,7 +82,7 @@ let genSinglePageInfoAsync (markdownPath: string) =
                      @ [ title [] [
                              str $"%s{pageTitle} | %s{siteName}"
                          ] ])
-                body [] [ rawText htmlContent ]
+                body [] htmlContent
             ]
 
         return

--- a/fs-education.fsproj
+++ b/fs-education.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="HtmlGen.fsi" />
     <Compile Include="HtmlGen.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>


### PR DESCRIPTION
Close #7 